### PR TITLE
new config for monitoring automation

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_repository.md
+++ b/.github/ISSUE_TEMPLATE/new_repository.md
@@ -15,6 +15,7 @@ Create a new repository with the name `helix-…`
 - [ ] Upload a social media image (use [this Spark template](https://spark.adobe.com/post/7srrIXaQVTw67/))
 - [ ] Set the repository description
 - [ ] Update the repository `README.md` (search for `adobe/helix-service` or `adobe/helix-library`)
+- [ ] Update the `statuspage` and `newrelic` config in `package.json`: decide if your service falls under Development, Publishing or Delivery. See https://status.project-helix.io for reference.
 - [ ] Set up [Project Bot]
   - [ ] Add a [`.github/org-project-bot.yaml`](https://github.com/adobe/helix-cli/blob/master/.github/org-project-bot.yaml)
   - [ ] Enable _OrgProjectBot_ under _Settings > Integrations & services or https://github.com/organizations/adobe/settings/installations/690408 (Adobe org admins only)


### PR DESCRIPTION
When creating a new repository from `helix-service`, the monitoring automation config must be changed as well.