### PR TITLE
docs(indexing): add proposal for sourceHash property

### DIFF
--- a/docs/observation/payload.md
+++ b/docs/observation/payload.md
@@ -6,7 +6,7 @@ Notifications received by a source repository, such as GitHub, OneDrive, Google 
 |------|------|-------------|
 | `type` | _string_ | provider type, possible values are `onedrive`, `github` or `google`. |
 | `owner` | _string_ | GitHub owner |
-| `repo` | _string_ | GitHub repository |
+| `repo` | _string_ | GitHub repository name |
 | `ref` | _string_ | GitHub reference |
 | `changes` | _array_ | [changes](#changes) observed, see below |
 | `mountpoint` | _object_ | [mountpoint](#mountpoint) affected, see below |

--- a/docs/observation/payload.md
+++ b/docs/observation/payload.md
@@ -1,6 +1,18 @@
 # Format of observation payload
 
-Notifications received by a source repository, such as GitHub, OneDrive, Google Drive, etc. have a provider specific format, e.g. OneDrive uses the format described on Microsoft's [docs](https://docs.microsoft.com/en-us/graph/api/driveitem-delta?view=graph-rest-1.0&tabs=http) site. When those notifications are received in the respective listener (e.g. `onedrive-change-listener` for OneDrive), they get converted to a portable format before sent to the next stage, e.g.:
+Notifications received by a source repository, such as GitHub, OneDrive, Google Drive, etc. have a provider specific format, e.g. OneDrive uses the format described on Microsoft's [docs](https://docs.microsoft.com/en-us/graph/api/driveitem-delta?view=graph-rest-1.0&tabs=http) site. When those notifications are received in the respective listener (e.g. `onedrive-change-listener` for OneDrive), they get converted to a portable format before sent to the next stage. The format
+has the following properties:
+
+| Name | Type | Description |
+|------|------|-------------|
+| `type` | _string_ | provider type, possible values are `onedrive`, `github` or `google`. |
+| `owner` | _string_ | GitHub owner |
+| `repo` | _string_ | GitHub repository |
+| `ref` | _string_ | GitHub reference |
+| `changes` | _array_ | [changes](#changes) observed, see below |
+| `mountpoint` | _object_ | [mountpoint](#mountpoint) affected, see below |
+
+An example payload for OneDrive might look as follows:
 
 ```
 {
@@ -12,41 +24,62 @@ Notifications received by a source repository, such as GitHub, OneDrive, Google 
     ...
   ],
   "mountpoint": {
-    "path": "/ms/",
-    "root": "/myshare"
+    ...
   }
 }
 ```
-The `changes` array contains an entry per change seen since the last batch of changes was sent, e.g. for OneDrive this might look as follows:
+
+## Changes
+
+The `changes` array contains an entry per change seen since the last batch of changes was sent. They have the following properties:
+
+For OneDrive again, this might look as follows:
+
+| Name | Type | Description |
+|------|------|-------------|
+| `path` | _string_ | item path, **required** for _added_ items, **optional** for _modified_ or _deleted_ items |
+| `time` | _string_ | time of change |
+| `type` | _string_ | `modified` for added or modified items, or `deleted` |
+| `uid`  | _string_ | unique identifier, required |
 
 ```
-{
-  "path": "/myshare/doc1",
+[{
+  "path": "/myshare/doc1.docx",
   "time": "2020-03-03T20:05:23Z",
   "type": "modified",
-  "provider": {
-    "sourceHash": "CvaY0bVa2e5dU6VT"
-  }
+  "uid": "CvaY0bVa2e5dU6VT"
 },
 {
   "time": "2020-03-03T20:05:26Z",
   "type": "deleted",
-  "provider": {
-    "sourceHash": "T4iuC3ycQbEG+TY/"
-  }
+  "uid": "T4iuC3ycQbEG+TY/"
+}]
+```
+
+## Mountpoint
+
+The `mountpoint` contains the information how paths in the changes array should be translated by replacing a prefix matching `root` with `path`:
+
+| Name | Type | Description |
+|------|------|-------------|
+| `root` | _string_ | Root folder path in the external provider |
+| `path` | _string_ | Path where root folder is mounted to |
+
+
+ e.g. for the following mountpoint:
+ ```
+{
+  "root": "/myshare",
+  "path": "/ms/"
 }
 ```
+and incoming change:
 
-The `provider` section contains provider specific information that might be required for downstream handlers. In the
-example above, a `sourceHash` is included that uniquely identifies items. The `path` property must be available for
-added or modified items, but may be missing for deleted items, if that information is no longer available.
-
-The `mountpoint` contains the information how paths in the changes array should be translated by replacing a prefix matching `root` with `path`, e.g. for the following change:
 ```
 {
-  "path": "/myshare/doc",
+  "path": "/myshare/doc1.docx",
   "time": "2020-03-03T20:05:23Z",
   "type": "modified"
 },
 ```
-the translated path is `/ms/doc`.
+the translated path is `/ms/doc1.docx`.

--- a/docs/observation/payload.md
+++ b/docs/observation/payload.md
@@ -36,7 +36,9 @@ The `changes` array contains an entry per change seen since the last batch of ch
 |------|------|-------------|
 | `path` | _string_ | item path, **required** for _added_ items, **optional** for _modified_ or _deleted_ items |
 | `time` | _string_ | time of change |
-| `type` | _string_ | `modified` for added or modified items, or `deleted` |
+| `type` | _string_ | change type. one of `modified`, 'added', 'deleted'<sup>1</sup> |
+
+<sup>1</sup> If the provider is not able to distinguish between `added` and `modified`, `modified` should be used.
 | `uid`  | _string_ | unique identifier, required |
 
 An example follows:

--- a/docs/observation/payload.md
+++ b/docs/observation/payload.md
@@ -5,30 +5,48 @@ Notifications received by a source repository, such as GitHub, OneDrive, Google 
 ```
 {
   "type": "onedrive",
-  "provider" {
-    "driveId": "..."
-  },
   "owner": "me",
   "repo": "myrepo",
   "ref": "master",
-  "mountpoint": {
-    "path": "/ms/",
-    "root": "/myshare"
-  },
   "changes": [
     ...
   ],
+  "mountpoint": {
+    "path": "/ms/",
+    "root": "/myshare"
+  }
 }
 ```
-The `provider` section contains provider specific information that might be required for downstream handlers.
+The `changes` array contains all an entry per change seen since the last batch of changes was sent, e.g. for OneDrive:
+
+```
+{
+  "path": "/myshare/doc1",
+  "time": "2020-03-03T20:05:23Z",
+  "type": "modified",
+  "provider": {
+    "sourceHash": "CvaY0bVa2e5dU6VT"
+  }
+},
+{
+  "time": "2020-03-03T20:05:26Z",
+  "type": "deleted",
+  "provider": {
+    "sourceHash": "T4iuC3ycQbEG+TY/"
+  }
+}
+```
+
+The `provider` section contains provider specific information that might be required for downstream handlers. In the
+example above, a `sourceHash` is included that uniquely identifies items. The `path` property must be available for
+added or modified items, but may be missing for deleted items, if that information is no longer available.
 
 The `mountpoint` contains the information how paths in the changes array should be translated by replacing a prefix matching `root` with `path`, e.g. for the following change:
 ```
 {
-  "id": "...",
-  "path": "/myshare/doc.md",
+  "path": "/myshare/doc",
   "time": "2020-03-03T20:05:23Z",
   "type": "modified"
 },
 ```
-the translated path is `/ms/doc.md`.
+the translated path is `/ms/doc`.

--- a/docs/observation/payload.md
+++ b/docs/observation/payload.md
@@ -7,7 +7,7 @@ Notifications received by a source repository, such as GitHub, OneDrive, Google 
 | `type` | _string_ | provider type, possible values are `onedrive`, `github` or `google`. |
 | `owner` | _string_ | GitHub owner |
 | `repo` | _string_ | GitHub repository name |
-| `ref` | _string_ | GitHub reference |
+| `ref` | _string_ | GitHub reference or branch name |
 | `changes` | _array_ | [changes](#changes) observed, see below |
 | `mountpoint` | _object_ | [mountpoint](#mountpoint) affected, see below |
 

--- a/docs/observation/payload.md
+++ b/docs/observation/payload.md
@@ -1,7 +1,6 @@
 # Format of observation payload
 
-Notifications received by a source repository, such as GitHub, OneDrive, Google Drive, etc. have a provider specific format, e.g. OneDrive uses the format described on Microsoft's [docs](https://docs.microsoft.com/en-us/graph/api/driveitem-delta?view=graph-rest-1.0&tabs=http) site. When those notifications are received in the respective listener (e.g. `onedrive-change-listener` for OneDrive), they get converted to a portable format before sent to the next stage. The format
-has the following properties:
+Notifications received by a source repository, such as GitHub, OneDrive, Google Drive, etc. have a provider specific format, e.g. OneDrive uses the format described on Microsoft's [docs](https://docs.microsoft.com/en-us/graph/api/driveitem-delta?view=graph-rest-1.0&tabs=http) site. When those notifications are received in the respective listener (e.g. `onedrive-change-listener` for OneDrive), they get converted to a portable format before sent to the next stage. The format has the following properties:
 
 | Name | Type | Description |
 |------|------|-------------|
@@ -33,8 +32,6 @@ An example payload for OneDrive might look as follows:
 
 The `changes` array contains an entry per change seen since the last batch of changes was sent. They have the following properties:
 
-For OneDrive again, this might look as follows:
-
 | Name | Type | Description |
 |------|------|-------------|
 | `path` | _string_ | item path, **required** for _added_ items, **optional** for _modified_ or _deleted_ items |
@@ -42,6 +39,7 @@ For OneDrive again, this might look as follows:
 | `type` | _string_ | `modified` for added or modified items, or `deleted` |
 | `uid`  | _string_ | unique identifier, required |
 
+An example follows:
 ```
 [{
   "path": "/myshare/doc1.docx",

--- a/docs/observation/payload.md
+++ b/docs/observation/payload.md
@@ -10,6 +10,7 @@ Notifications received by a source repository, such as GitHub, OneDrive, Google 
 | `ref` | _string_ | GitHub reference or branch name |
 | `changes` | _array_ | [changes](#changes) observed, see below |
 | `mountpoint` | _object_ | [mountpoint](#mountpoint) affected, see below |
+| `provider` | _object_ | provider specific information |
 
 An example payload for OneDrive might look as follows:
 
@@ -24,6 +25,9 @@ An example payload for OneDrive might look as follows:
   ],
   "mountpoint": {
     ...
+  },
+  "provider": {
+    "driveId": "b!-RIj2DuyvEyV1T4NlOaMHk8XkS_I8MdFlUCq1BlcjgmhRfAj3-Z8RY2VpuvV_tpd"
   }
 }
 ```
@@ -36,10 +40,10 @@ The `changes` array contains an entry per change seen since the last batch of ch
 |------|------|-------------|
 | `path` | _string_ | item path, **required** for _added_ items, **optional** for _modified_ or _deleted_ items |
 | `time` | _string_ | time of change |
-| `type` | _string_ | change type. one of `modified`, 'added', 'deleted'<sup>1</sup> |
+| `type` | _string_ | change type. one of `modified`, `added`, `deleted`<sup>1</sup> |
+| `uid`  | _string_ | unique identifier, required |
 
 <sup>1</sup> If the provider is not able to distinguish between `added` and `modified`, `modified` should be used.
-| `uid`  | _string_ | unique identifier, required |
 
 An example follows:
 ```

--- a/docs/observation/payload.md
+++ b/docs/observation/payload.md
@@ -1,6 +1,6 @@
 # Format of observation payload
 
-Notifications received by a source repository, such as GitHub, OneDrive, Google Drive, etc. have a provider specific format, e.g. OneDrive uses the format described on Microsoft's [docs](https://docs.microsoft.com/en-us/graph/api/driveitem-delta?view=graph-rest-1.0&tabs=http) site. When those notifications are received in the `onedrive-change-listener`, they get converted to a portable format before sent to the next stage, e.g.:
+Notifications received by a source repository, such as GitHub, OneDrive, Google Drive, etc. have a provider specific format, e.g. OneDrive uses the format described on Microsoft's [docs](https://docs.microsoft.com/en-us/graph/api/driveitem-delta?view=graph-rest-1.0&tabs=http) site. When those notifications are received in the respective listener (e.g. `onedrive-change-listener` for OneDrive), they get converted to a portable format before sent to the next stage, e.g.:
 
 ```
 {
@@ -17,7 +17,7 @@ Notifications received by a source repository, such as GitHub, OneDrive, Google 
   }
 }
 ```
-The `changes` array contains all an entry per change seen since the last batch of changes was sent, e.g. for OneDrive:
+The `changes` array contains an entry per change seen since the last batch of changes was sent, e.g. for OneDrive this might look as follows:
 
 ```
 {


### PR DESCRIPTION
New proposal to remove extension automatically and add a `sourceHash` provider property.

Just wondering: couldn't we just call that thing `id`, and request its uniqueness, whatever its underlying semantics?