### PR TITLE
chore: add index.html with redirect to README.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,6 @@
+<html>
+  <head>
+    <meta http-equiv="refresh" content="0;url=/README.html" />
+  </head>
+  <body></body>
+</html>


### PR DESCRIPTION
Fixes https://helix-home-adobe.hlx.page, since we no longer auto-redirect to /README.html in Helix Pages.