### PR TITLE
Add DA & EW track topics to Basel Ops Workshop

### DIFF
--- a/hackathons/20-bsl.md
+++ b/hackathons/20-bsl.md
@@ -50,6 +50,13 @@ Let's make the list of topics more of operational tasks, than garage week style 
 
 - R.I.P `fstab.yaml` (replace with bootstrap (https://github.com/adobe/helix-bot/issues/1908) and clean documentation)
 - Remove all file based config references and examples in documentation
+
+#### DA & EW Track
+
+- DA & EW alignment & cleanup (component model, shared components)
+- Move to NX2 (browse, landing, start page, ...)
+- DA/EW & HLX 6 alignment (ongoing effort, sync on current status and next steps)
+- Permissions in DA (& HLX6) - current shortcomings and improvements
   
 ### Attendees
 


### PR DESCRIPTION
## Summary

- Adds a new **DA & EW Track** section to the Basel Ops Workshop 20 agenda
- Topics covered:
  - DA & EW alignment & cleanup (component model, shared components)
  - Move to NX2 (browse, landing, start page, ...)
  - DA/EW & HLX 6 alignment
  - Permissions in DA (& HLX6) - current shortcomings and improvements

🤖 Generated with [Claude Code](https://claude.com/claude-code)