### PR TITLE
Fix mojibake in oversight SKILL.md introduced by #473

### DIFF
--- a/skills/oversight/SKILL.md
+++ b/skills/oversight/SKILL.md
@@ -416,23 +416,23 @@ and the `weightedThreshold` helper in `src/support/util.js`.
 
 ### Gotchas
 
-- **Don't skip `utils.addCalculatedProps(b)`**  it walks `b.events`, sets
+- **Don't skip `utils.addCalculatedProps(b)`** — it walks `b.events`, sets
   `b.visit = true` when an `enter` checkpoint exists, and copies CWV values
   out of `cwv-lcp` / `cwv-cls` / `cwv-inp` events into `b.cwvLCP` / `b.cwvCLS` /
   `b.cwvINP`. Skip it and visits/vitals come back as 0/undefined.
-- **The bundler API normalizes URLs**: numeric path segments � `<number>`,
-  long hex � `<hex>`, UUIDs � `<uuid>`. Treat `facets.url` values as URL
+- **The bundler API normalizes URLs**: numeric path segments → `<number>`,
+  long hex → `<hex>`, UUIDs → `<uuid>`. Treat `facets.url` values as URL
   *patterns*, not literal URLs.
 - **Each bundle has a `weight` field** (e.g. 100, 700, 1000) representing the
   inverse sampling rate. Series functions return `weight` (not 1) when their
-  predicate matches  that's how `.sum` becomes the weight-adjusted estimate.
-- **Use `--range=year` cautiously**  pulling 12 months of bundles for a busy
+  predicate matches — that's how `.sum` becomes the weight-adjusted estimate.
+- **Use `--range=year` cautiously** — pulling 12 months of bundles for a busy
   domain can fetch tens of thousands of records. Prefer monthly `/YYYY/MM`
   endpoints in a loop so you can show progress and resume.
 - **Top-level `await` works in `.mjs` files**, but `import x from '...'`
   syntax is rejected by the realm worker. Use `await import(...)` exclusively.
 - **`fs.writeFile` is the global SLICC `fs`**, not `node:fs`. Don't try to
-  `import('node:fs')`  that 404s in the realm. Just call `await fs.writeFile(...)`.
+  `import('node:fs')` — that 404s in the realm. Just call `await fs.writeFile(...)`.
 
 ### When to reach for rum-distiller vs. the CLI
 
@@ -454,9 +454,9 @@ and the `weightedThreshold` helper in `src/support/util.js`.
 
 ## Don't
 
-- Don't use raw event counts  always weight-adjusted (`sum of weights`)
+- Don't use raw event counts — always weight-adjusted (`sum of weights`)
 - Don't expose admin keys or domain keys in logs, commit messages, or PR descriptions
-- Don't assume a domain key exists  mint one first if you get 401 on bundle fetches
+- Don't assume a domain key exists — mint one first if you get 401 on bundle fetches
 - Don't confuse GET (retrieve existing key) with POST (mint new key) on `/domainkey/`
-- Don't forget `utils.addCalculatedProps(b)` before loading bundles into `DataChunks` 
+- Don't forget `utils.addCalculatedProps(b)` before loading bundles into `DataChunks` —
   visits and core-web-vitals series silently return zero/undefined without it


### PR DESCRIPTION
## Summary

Fixes mojibake (corrupted characters) in `skills/oversight/SKILL.md` introduced by #473.

Two Unicode characters were truncated to their low byte:

| Corrupt byte | Correct character | Occurrences |
|---|---|---|
| `0x14` (DC4 control char) | `—` em-dash (U+2014) | 7 |
| `0x92` (lone high byte) | `→` right-arrow (U+2192) | 3 |

## Details

- Affected lines: 419, 423, 424, 428, 429, 435, 457, 459, 461 (all in the "Gotchas" / "Don't" sections).
- Fix was applied byte-precisely. The file also contains 4 **valid** `0x92` continuation bytes (part of legitimate `→` arrows on lines 74/75/289/290); those were preserved via position-based replacement rather than a global byte swap.
- Only `skills/oversight/SKILL.md` is changed (9 insertions, 9 deletions). The other 8 files added by #473 were already valid UTF-8 and are untouched.

## Verification

The file now decodes as valid UTF-8 with zero C0 control bytes:

```
decode: valid-utf8 | C0 controls: 0 -> OK / clean
em-dash count: 27  (20 pre-existing + 7 fixed)
right-arrow count: 7  (4 pre-existing + 3 fixed)
```


---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author