### PR TITLE
fix(klickhaus): fs is not defined — use skill config bridge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .DS_Store
 .hlx
 logs
+# klickhaus skill stores ClickHouse credentials in a per-skill config bridge file
+skills/klickhaus/scripts/.config

--- a/skills/klickhaus/scripts/klickhaus.jsh
+++ b/skills/klickhaus/scripts/klickhaus.jsh
@@ -1,8 +1,12 @@
 // Klickhaus — CDN incident investigation tool
 // Queries AEM Edge Delivery Services CDN logs in ClickHouse
 
-const CONFIG_DIR = (process.env.HOME || process.env.USERPROFILE || '/root') + '/.config/klickhaus';
-const CONFIG_FILE = CONFIG_DIR + '/config.json';
+// Runtime bridges: in the SLICC .jsh runtime former bare globals are exposed
+// via require('sliccy:<name>') / require('fs'). Credentials are persisted
+// through the per-skill config bridge (skill.config), which writes a
+// gitignored `.config` next to the skill — no raw fs to $HOME.
+const skill = require('sliccy:skill');
+
 const CLICKHOUSE_URL = 'https://s2p5b8wmt5.eastus2.azure.clickhouse.cloud/';
 const DATABASE = 'helix_logs_production';
 
@@ -34,24 +38,17 @@ const DIMENSIONS = {
 
 // --- Config ---
 
-let _config = null;
-
 async function loadConfig() {
-  if (_config) return _config;
-  try {
-    const raw = await fs.readFile(CONFIG_FILE, 'utf8');
-    _config = JSON.parse(raw);
-    return _config;
-  } catch (e) {
-    return null;
-  }
+  // skill.config() reads the parsed JSON from the skill's gitignored `.config`
+  // (returns null when it does not exist yet). Must await before any fallback:
+  // the raw call returns a Promise, which is always truthy.
+  return (await skill.config()) || null;
 }
 
 async function saveConfig(config) {
-  _config = config;
-  await fs.mkdir(CONFIG_DIR, { recursive: true }).catch(function() {});
-  await fs.writeFile(CONFIG_FILE, JSON.stringify(config, null, 2));
-  await fs.chmod(CONFIG_FILE, 0o600).catch(function() {});
+  // skill.config(updates) shallow-merges and persists to the skill's
+  // gitignored `.config`, returning the merged object.
+  return await skill.config(config);
 }
 
 async function ensureAuth() {
@@ -177,7 +174,7 @@ async function cmdLogin(args) {
   }
 
   await saveConfig({ user, password, logged_in_at: new Date().toISOString() });
-  console.log('Login successful. Config saved to ' + CONFIG_FILE);
+  console.log('Login successful. Credentials saved to the klickhaus skill config (gitignored).');
   console.log('');
   console.log('Try:');
   console.log('  klickhaus status');
@@ -611,7 +608,10 @@ async function cmdQuery(args) {
   const fileArg = args.find(a => a.startsWith('--file='));
   if (fileArg) {
     const filePath = fileArg.split('=').slice(1).join('=');
-    sql = await fs.readFile(filePath, 'utf8');
+    // The SLICC VFS fs bridge must be require()'d; its sync API (readFileSync)
+    // behaves like Node's, unlike the promise-style methods.
+    const fs = require('fs');
+    sql = fs.readFileSync(filePath, 'utf8');
   } else if (args.length > 0) {
     sql = args.join(' ');
   } else if (!process.stdin.isTTY) {


### PR DESCRIPTION
## The bug

`skills/klickhaus/scripts/klickhaus.jsh` referenced a bare `fs` global that does not exist in the SLICC `.jsh` runtime:

- `loadConfig()` → `await fs.readFile(CONFIG_FILE, 'utf8')`
- `saveConfig()` → `await fs.mkdir(...)`, `fs.writeFile(...)`, `fs.chmod(...)`
- `cmdQuery()` (`--file=`) → `await fs.readFile(filePath, 'utf8')`

In the `.jsh` runtime former bare globals were migrated to `require('sliccy:<name>')` / `require('fs')` bridges, so `fs` is undefined. Every command failed at `loadConfig` (via `ensureAuth`) and `klickhaus login` failed at `saveConfig`, both throwing `ReferenceError: fs is not defined`. Reproduced live.

## The cause

Nothing imports `fs`. The old code also used Node-style promise `fs` methods (`readFile(path,'utf8')`, `mkdir`, `chmod`) that don't match the SLICC VFS bridge (where `chmod` is a no-op and the promise-style text methods don't behave like Node).

## The fix

Adopt the idiomatic SLICC per-skill **config bridge** (`require('sliccy:skill')`), matching the `.jsh` migration convention used across sibling skills (garmin, slack, elevenlabs, etc.):

- `loadConfig()` → `return (await skill.config()) || null;`
- `saveConfig(config)` → `return await skill.config(config);`

`skill.config()` reads/writes a gitignored per-skill `.config` file, so the `$HOME/.config/klickhaus/config.json` + raw `fs` logic (and the `fs` dependency for credential storage) is removed entirely. Credentials are still `{ user, password, logged_in_at }` and used for ClickHouse basic auth exactly as before; the `login` UX (flags, `SELECT 1` test, "Login successful" output) is unchanged apart from the storage-location message.

The one legitimate file read — `klickhaus query --file=<path>` — now uses a properly `require('fs')`'d handle with the sync API (`readFileSync`), which behaves like Node's unlike the promise-style methods.

A `.gitignore` entry (`skills/klickhaus/scripts/.config`) is added so the credential file is never committed.

## Live-test evidence

Ran in the same `.jsh` runtime after deploying the edited file:

```
$ klickhaus login --user=trieloff_adobe_com --password=***
Login successful. Credentials saved to the klickhaus skill config (gitignored).

$ klickhaus query "SELECT 1 AS ok"
{ "data": [ { "ok": 1 } ], "rows": 1, ... }          # HTTP 200

$ klickhaus status
{ "period": "last 1 hour", "total_requests": 5614905, "errors_5xx": 11, ... }

$ klickhaus query --file=q.sql
{ "data": [ { "answer": 42 } ], "rows": 1, ... }
```

All commands run using stored creds with no `fs`/not-defined error. No credentials are committed (the config bridge stores them in the gitignored `.config`; verified the file is absent from the branch).

Found while using the skill to watch a DNS change.