### PR TITLE
fix(skills): .jsh migration — require fs/sliccy:exec, skill config bridge (oncall, postmortem, oversight)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .DS_Store
 .hlx
 logs
+# oversight skill stores the RUM admin key + domain keys in a per-skill config bridge file
+skills/oversight/scripts/.config

--- a/skills/adobe-oncall/scripts/oncall.jsh
+++ b/skills/adobe-oncall/scripts/oncall.jsh
@@ -1,6 +1,13 @@
 // Adobe On-Call — incident management skill
 // Uses ServiceNow Table API + UX Databroker from workspace page context.
 
+// Runtime bridges: in the SLICC .jsh runtime the former bare `exec` and `fs`
+// globals are exposed via require('sliccy:exec') / require('fs'). Without these
+// imports every command throws `ReferenceError: exec is not defined` (in
+// ensureTab) / `fs is not defined` (in the XHR eval helpers).
+const exec = require('sliccy:exec');
+const fs = require('fs');
+
 const DOMAIN = 'adobe.service-now.com';
 const ONCALL_PATH = '/x/adosy/on-call/home';
 const INCIDENT_TABLE = 'x_adosy_adb_on_ca_incident';

--- a/skills/aem-postmortem/scripts/postmortem.jsh
+++ b/skills/aem-postmortem/scripts/postmortem.jsh
@@ -1,6 +1,11 @@
 // AEM Postmortem — manage incident post-mortems for AEM Edge Delivery Services
 // Works with the aem-status repo at /workspace/aem-status/
 
+// In the SLICC .jsh runtime the former bare `fs` global is exposed via
+// require('fs') (VFS bridge). Without this import every file command throws
+// `ReferenceError: fs is not defined`.
+const fs = require('fs');
+
 const INCIDENTS_DIR = '/workspace/aem-status/incidents/md';
 const INDEX_FILE = '/workspace/aem-status/incidents/index.json';
 const TEMPLATE_SHORT = INCIDENTS_DIR + '/incident-template-short.markdown';

--- a/skills/oversight/scripts/oversight.jsh
+++ b/skills/oversight/scripts/oversight.jsh
@@ -1,30 +1,27 @@
 // Oversight — RUM / Operational Telemetry query tool
 // Queries AEM Edge Delivery Services RUM data via bundles.aem.page
 
-const CONFIG_DIR = (process.env.HOME || process.env.USERPROFILE || '/root') + '/.config/oversight';
-const CONFIG_FILE = CONFIG_DIR + '/config.json';
 const API_ENDPOINT = 'https://bundles.aem.page';
+
+// Runtime bridges: in the SLICC .jsh runtime former bare globals are exposed
+// via require('sliccy:<name>'). Credentials (the RUM admin key and cached
+// domain keys) are persisted through the per-skill config bridge (skill.config),
+// which writes a gitignored `.config` next to the skill — no raw fs to $HOME.
+const skill = require('sliccy:skill');
 
 // --- Config ---
 
-let _config = null;
-
 async function loadConfig() {
-  if (_config) return _config;
-  try {
-    const raw = await fs.readFile(CONFIG_FILE, 'utf8');
-    _config = JSON.parse(raw);
-    return _config;
-  } catch (e) {
-    return { adminKey: '', domainKeys: {} };
-  }
+  // skill.config() reads the parsed JSON from the skill's gitignored `.config`
+  // (returns null when it does not exist yet). Must await before the fallback:
+  // the raw call returns a Promise, which is always truthy.
+  return (await skill.config()) || { adminKey: '', domainKeys: {} };
 }
 
 async function saveConfig(config) {
-  _config = config;
-  await fs.mkdir(CONFIG_DIR, { recursive: true }).catch(function() {});
-  await fs.writeFile(CONFIG_FILE, JSON.stringify(config, null, 2));
-  await fs.chmod(CONFIG_FILE, 0o600).catch(function() {});
+  // skill.config(updates) shallow-merges and persists to the skill's
+  // gitignored `.config`, returning the merged object.
+  return await skill.config(config);
 }
 
 async function ensureAdminKey() {
@@ -292,7 +289,7 @@ async function cmdLogin(args) {
   config.adminKey = opts.key;
   config.domainKeys = config.domainKeys || {};
   await saveConfig(config);
-  console.log('Admin key saved to ' + CONFIG_FILE);
+  console.log('Admin key saved to the oversight skill config (gitignored).');
   console.log('');
   console.log('Next steps:');
   console.log('  oversight mint <domain>     — mint a domain key');


### PR DESCRIPTION
Follow-up to #485 (klickhaus). Audits the remaining `skills/` `.jsh` scripts for the same SLICC `.jsh` migration bug class — former bare globals (`fs`, `exec`, …) are now behind `require('sliccy:<name>')` / `require('fs')`, so using them implicitly throws `ReferenceError: X is not defined` at runtime.

All three audited skills were **runtime-breaking**. Full findings report: `helix-home-skills-audit.md`.

## `adobe-oncall/scripts/oncall.jsh`
- **Bug:** `exec(...)` (tab management) and `fs.writeFile`/`fs.rm` (XHR eval temp files) used without `require` → `ReferenceError: exec is not defined` / `fs is not defined` on the first real command.
- **Fix:** `const exec = require('sliccy:exec');` (returns `{stdout,stderr,exitCode}`, matches usage) and `const fs = require('fs');`. No behavior change.
- **Live test:** `oncall --help` OK; `oncall who` runs through `exec` (playwright-cli) + `fs.writeFile`/`fs.rm` + databroker eval and lands on the graceful `Could not retrieve on-call calendar.` (no ServiceNow session available in the test env) — **no ReferenceError**.
- *Recommendation (not in this PR):* the `playwright-cli`-shelling could later move to `require('sliccy:browser')`; it is functional today so left as-is to keep the diff minimal.

## `aem-postmortem/scripts/postmortem.jsh`
- **Bug:** `fs.readFile`/`fs.exists`/`fs.writeFile` used without `require` → `list`, `get`, `new`, `classify`, `branch`, `monday` all throw `ReferenceError: fs is not defined`.
- **Fix:** `const fs = require('fs');` (the async methods behave correctly once required). No behavior change; no credentials involved.
- **Live test (local `aem-status` fixture):** `list` reads `index.json`, `new` reads a template + writes the incident file, `get` reads it back, `impact 0.034` → `minor`. All succeed with no `fs is not defined`.

## `oversight/scripts/oversight.jsh`
- **Bug:** credentials (RUM admin key + cached domain keys) stored at `$HOME/.config/oversight/config.json` via `fs.readFile`/`fs.mkdir`/`fs.writeFile`/`fs.chmod` without `require` → every command throws `ReferenceError: fs is not defined` (and `chmod 0600` is a no-op in the VFS anyway).
- **Fix (Option A, mirrors #485):** use the `sliccy:skill` config bridge — `require('sliccy:skill')`, `loadConfig` → `(await skill.config()) || { adminKey:'', domainKeys:{} }`, `saveConfig` → `await skill.config(config)`. Removes the raw-`fs`/`$HOME` logic; config shape (`{ adminKey, domainKeys }`) and all HTTP/auth behavior preserved. Added `.gitignore` entry `skills/oversight/scripts/.config` so the credential file is never committed.
- **Live test:** `oversight keys` → `No domain keys cached...` (exercises `loadConfig` via the bridge with the default fallback, no fs error); usage-error paths OK. Not logged into the RUM bundler API (no admin key; no Bearer token fabricated against the live endpoint), so mint/status data paths were verified statically + via the config-read path.

## Notes
- No credentials committed; `.config` files are gitignored and absent from the branch (verified).
- Found while auditing the skills after the klickhaus DNS-watch fix (#485).
- Do not merge without review.