### PR TITLE
klickhaus: auto-detect credentials from a logged-in dashboard tab

### DIFF
--- a/skills/klickhaus/SKILL.md
+++ b/skills/klickhaus/SKILL.md
@@ -72,6 +72,27 @@ cat query.sql | klickhaus query
 
 `host`, `status`, `path`, `content_type`, `cache`, `method`, `request_type`, `backend_type`, `forwarded_host`, `referer`, `user_agent`, `datacenter`, `asn`, `ip`
 
+## Incident RCA playbook
+
+Fast root-cause routine for a "More than 100 5xx on aem.(page|live) in 10m" style alert:
+
+1. **Find the burst, not the average.** The alert is about a ~10-minute window; the `1h` rollup hides a short spike. Bucket per-minute to locate the exact minute(s) and to confirm recovery:
+   `klickhaus query "SELECT toStartOfMinute(timestamp) m, sum(weight) c FROM delivery WHERE timestamp >= now()-INTERVAL 30 MINUTE AND intDiv(\`response.status\`,100)=5 GROUP BY m ORDER BY m"`
+2. **`x_error` is the #1 discriminator.** Break down `response.headers.x_error` for the 5xx — it maps almost 1:1 to a subsystem:
+   - `first byte timeout` / `[pipeline: html] first byte timeout` → rendering **pipeline** slow/unresponsive.
+   - `All backends failed or unhealthy (chash)` → **Fastly** director found all backends unhealthy → usually a **PoP-level network/reachability** problem (confirm it's localized — see below).
+   - `[media] Service Unavailable` / `[media] [IO] Error transforming image` → **media/image** backend.
+   - `Worker: x-error: failed to load … from content-bus: 500` → **content-bus**.
+   - `[static: …] R2: …` → **R2** storage.
+   - `Worker: Service Unavailable` on `main--project-elmo-ui-data--adobe.aem.live` → known **Project Elmo** huge-JSON worker OOM (already excluded from the trigger).
+3. **Localize by datacenter.** `breakdown datacenter` (or group by `cdn.datacenter`) on the 5xx. All errors in ONE PoP while others are clean = a **PoP/network** issue, not a backend outage. `KUL, KNU, VNS, IXD, BOM, SIN, FRA, IAD…` are **Fastly** PoP codes.
+4. **Scope by tenant.** `breakdown host`: many unrelated tenants → **infrastructure**; a single host → **customer/app**.
+5. **Confirm recovery / recurrence.** Re-poll per-minute (mind the ingest lag, below); check the last 24h by `datacenter`+hour to see whether the exact `x_error` is a known recurring regional pattern.
+
+**CDN layering (don't conflate):** the `delivery` edge is **Fastly** (note the `cdn.fastly_error` column, and the Fastly PoP codes in `cdn.datacenter`). `helix.backend_type` (`aws`/`cloudflare`) is the **origin type behind** Fastly, NOT the CDN. So a `backends failed (chash)` error with `backend_type=aws` is a **Fastly-edge→origin** reachability failure, not an AWS outage.
+
+**Known non-incidents already excluded from the alert trigger:** Project Elmo huge-JSON worker OOM (503 `Worker: Service Unavailable`), and Cloudflare `530`s from the `websiphon-x2` scanner (UA blocked at the edge).
+
 ## Architecture
 
 - **Database**: ClickHouse Cloud (`helix_logs_production`)
@@ -85,3 +106,6 @@ cat query.sql | klickhaus query
 - Don't use `count(*)` — always `sum(weight)` for accurate counts (data is sampled)
 - Don't forget backticks around dotted column names in ClickHouse
 - Don't query without a time filter — tables have 2-week TTL but are large
+- Don't append `FORMAT JSON` to `klickhaus query` SQL — the command adds it for you (a trailing `FORMAT` is a syntax error)
+- Don't read the freshest 1–2 minutes as gospel — ingestion lags ~1–2 min, so the latest minute(s) may be empty or partial; confirm recovery against minutes a couple back
+- Don't conflate `helix.backend_type` (origin behind Fastly) with the CDN edge (Fastly) — see the RCA playbook

--- a/skills/klickhaus/SKILL.md
+++ b/skills/klickhaus/SKILL.md
@@ -13,7 +13,10 @@ CLI tool for querying AEM Edge Delivery Services CDN logs in ClickHouse. Designe
 
 ```bash
 # First time — store credentials
-klickhaus login
+klickhaus login --user=USERNAME --password=PASSWORD
+
+# Or reuse an open, logged-in klickhaus dashboard tab (no manual creds):
+klickhaus login --from-tab
 
 # Is something wrong right now?
 klickhaus status
@@ -47,7 +50,7 @@ cat query.sql | klickhaus query
 
 | Command | Purpose |
 |---------|---------|
-| `login` | Store ClickHouse credentials |
+| `login` | Store ClickHouse credentials (`--user`/`--password`, or `--from-tab` to reuse a logged-in dashboard tab) |
 | `status` | Quick health check: total requests, error rates, top error hosts (last hour) |
 | `errors` | Error breakdown by host, path, status code |
 | `timeseries` | Time series of ok/4xx/5xx traffic |
@@ -72,7 +75,7 @@ cat query.sql | klickhaus query
 ## Architecture
 
 - **Database**: ClickHouse Cloud (`helix_logs_production`)
-- **Auth**: Basic auth over HTTPS (credentials stored in `$HOME/.config/klickhaus/config.json` with mode 0600, outside the repository)
+- **Auth**: Basic auth over HTTPS. Credentials are stored via the per-skill config bridge (a gitignored `.config` next to the skill). If the config is empty, the tool auto-detects credentials from a logged-in `klickhaus.aemstatus.net` browser tab (localStorage key `clickhouse_credentials`) and logs in transparently — so `status`/`errors`/etc. just work when the dashboard is open.
 - **Sampling**: Rows are sampled — always uses `sum(weight)` not `count(*)`
 - **Tables**: `delivery` (CDN edge), `admin` (admin service), `backend` (backend services), `da` (Document Authoring)
 - **Key columns**: `timestamp`, `response.status`, `request.host`, `request.url`, `weight`

--- a/skills/klickhaus/SKILL.md
+++ b/skills/klickhaus/SKILL.md
@@ -93,6 +93,16 @@ Fast root-cause routine for a "More than 100 5xx on aem.(page|live) in 10m" styl
 
 **Known non-incidents already excluded from the alert trigger:** Project Elmo huge-JSON worker OOM (503 `Worker: Service Unavailable`), and Cloudflare `530`s from the `websiphon-x2` scanner (UA blocked at the edge).
 
+### RCA reasoning principles
+
+Signature-matching finds *symptoms*; these keep you honest about *cause*:
+
+- **Attribute the failure to the layer that *emitted* the error, not the nearest labeled field.** Every field has a role — edge / origin / client / subsystem. Identify which component produced the error, then read each field relative to that emitter. Example trap: `backends failed (chash)` with `helix.backend_type=aws` is a **Fastly-edge→origin** reachability failure; `aws` names the *destination*, not the culprit. Don't let the most id-like value in the row become the defendant.
+- **Pivot on the invariant, not the vivid.** To correlate anomalies, group by the dimension that stays *constant* across them, not the flashiest attribute. Surface signatures diverge: **different `x_error`/status ≠ different root cause**, and **the same `x_error` ≠ the same root cause**. (One regional Fastly egress fault showed up as `chash` for pipeline→AWS *and* `[media] Service Unavailable` for media→Cloudflare — same cause, different dialects.)
+- **Differences are weak evidence of separateness.** Before declaring two incidents unrelated, test whether one upstream factor explains both. Being precise about *how* they differ is not the same as being right about *whether they share a cause*.
+- **Mandatory second pivot / cross-tabulate to falsify.** Never conclude from one breakdown. Re-slice by an orthogonal dimension (`datacenter` × `backend_type` × `x_error` × `host` × time) and keep the pivot where your hypothesized cause explains the variance *and the leading alternative does not*. Litmus used here: region predicts failure, backend provider does not (it spans both AWS and Cloudflare) → regional/Fastly, not a provider outage.
+- **Separate description from causation in the writeup.** "It involved AWS origins" (descriptive) is not "the AWS backend failed" (causal). Conflating the two is the classic misattribution.
+
 ## Architecture
 
 - **Database**: ClickHouse Cloud (`helix_logs_production`)

--- a/skills/klickhaus/scripts/klickhaus.jsh
+++ b/skills/klickhaus/scripts/klickhaus.jsh
@@ -7,8 +7,21 @@
 // gitignored `.config` next to the skill — no raw fs to $HOME.
 const skill = require('sliccy:skill');
 
+// Optional browser bridge — used to auto-detect credentials from a logged-in
+// klickhaus web tab. Guarded so the tool still works in environments where the
+// browser bridge is unavailable (e.g. pure CI).
+let browser = null;
+try { browser = require('sliccy:browser'); } catch (_) { /* no browser bridge */ }
+
 const CLICKHOUSE_URL = 'https://s2p5b8wmt5.eastus2.azure.clickhouse.cloud/';
 const DATABASE = 'helix_logs_production';
+
+// The klickhaus web dashboard (https://klickhaus.aemstatus.net) stores the
+// ClickHouse basic-auth creds in localStorage under this key as
+// {"user":"...","password":"..."}. If a logged-in tab is open we can reuse it
+// so `klickhaus login` needs no manual credential entry.
+const KLICKHAUS_WEB_DOMAIN = 'klickhaus.aemstatus.net';
+const CREDS_LS_KEY = 'clickhouse_credentials';
 
 const TIME_RANGES = {
   '15m': { interval: 'INTERVAL 15 MINUTE', bucket: "toStartOfInterval(timestamp, INTERVAL 1 MINUTE)", step: 'INTERVAL 1 MINUTE' },
@@ -51,13 +64,44 @@ async function saveConfig(config) {
   return await skill.config(config);
 }
 
+// Try to read ClickHouse credentials from a logged-in klickhaus web tab.
+// Returns { user, password, source } or null. Never throws — any failure
+// (no browser bridge, no open tab, no stored creds) resolves to null so
+// callers can fall back gracefully.
+async function credsFromTab() {
+  if (!browser) return null;
+  try {
+    const tab = await browser.findTab({ domain: KLICKHAUS_WEB_DOMAIN });
+    if (!tab) return null;
+    const raw = await browser.localStorage(tab, CREDS_LS_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    if (parsed && parsed.user && parsed.password) {
+      return { user: parsed.user, password: parsed.password, source: 'tab' };
+    }
+  } catch (_) { /* fall through to null */ }
+  return null;
+}
+
+// Ensure we have working credentials, auto-detecting from a logged-in
+// klickhaus web tab if the skill config is not yet populated.
 async function ensureAuth() {
   const config = await loadConfig();
-  if (!config || !config.user || !config.password) {
-    console.error('Not logged in. Run `klickhaus login` first.');
-    process.exit(1);
+  if (config && config.user && config.password) return config;
+
+  // Not configured yet — try to auto-detect a logged-in klickhaus web tab
+  // before giving up, so the tool works out of the box when the dashboard
+  // is open in the browser.
+  const fromTab = await credsFromTab();
+  if (fromTab) {
+    await saveConfig({ user: fromTab.user, password: fromTab.password, logged_in_at: new Date().toISOString(), source: 'tab' });
+    console.error('Detected credentials from an open ' + KLICKHAUS_WEB_DOMAIN + ' tab — logged in automatically.');
+    return { user: fromTab.user, password: fromTab.password };
   }
-  return config;
+
+  console.error('Not logged in. Run `klickhaus login` first');
+  console.error('(or open ' + KLICKHAUS_WEB_DOMAIN + ' in a logged-in tab and re-run — creds are picked up automatically).');
+  process.exit(1);
 }
 
 // --- Query engine ---
@@ -142,16 +186,34 @@ async function cmdLogin(args) {
   // Parse --user= and --password= from args
   let user = null;
   let password = null;
+  let fromTabFlag = false;
   for (let i = 0; i < args.length; i++) {
     if (args[i].startsWith('--user=')) user = args[i].split('=').slice(1).join('=');
     else if (args[i].startsWith('--password=')) password = args[i].split('=').slice(1).join('=');
+    else if (args[i] === '--from-tab' || args[i] === '--tab') fromTabFlag = true;
     else if (!user) user = args[i];
     else if (!password) password = args[i];
+  }
+
+  // If no explicit creds were given (or --from-tab was requested), try to
+  // pick them up from a logged-in klickhaus web tab.
+  if (fromTabFlag || (!user || !password)) {
+    const fromTab = await credsFromTab();
+    if (fromTab) {
+      user = fromTab.user;
+      password = fromTab.password;
+      console.error('Using credentials from an open ' + KLICKHAUS_WEB_DOMAIN + ' tab.');
+    } else if (fromTabFlag) {
+      console.error('No logged-in ' + KLICKHAUS_WEB_DOMAIN + ' tab found.');
+      console.error('Open the klickhaus dashboard in the browser and log in, then retry — or pass --user/--password.');
+      process.exit(1);
+    }
   }
 
   if (!user || !password) {
     console.error('Usage: klickhaus login --user=USERNAME --password=PASSWORD');
     console.error('   or: klickhaus login USERNAME PASSWORD');
+    console.error('   or: klickhaus login --from-tab   (reuse an open, logged-in ' + KLICKHAUS_WEB_DOMAIN + ' tab)');
     console.error('');
     console.error('URL: ' + CLICKHOUSE_URL);
     console.error('Database: ' + DATABASE);

--- a/skills/klickhaus/scripts/klickhaus.jsh
+++ b/skills/klickhaus/scripts/klickhaus.jsh
@@ -195,19 +195,30 @@ async function cmdLogin(args) {
     else if (!password) password = args[i];
   }
 
-  // If no explicit creds were given (or --from-tab was requested), try to
-  // pick them up from a logged-in klickhaus web tab.
-  if (fromTabFlag || (!user || !password)) {
+  // If no explicit creds were given at all (or --from-tab was requested),
+  // try to pick them up from a logged-in klickhaus web tab. A *partial*
+  // credential (only one of --user/--password) must never silently fall
+  // back to tab creds and override the caller's intent — that case is
+  // rejected explicitly below.
+  let source = 'manual';
+  if (fromTabFlag || (!user && !password)) {
     const fromTab = await credsFromTab();
     if (fromTab) {
       user = fromTab.user;
       password = fromTab.password;
+      source = 'tab';
       console.error('Using credentials from an open ' + KLICKHAUS_WEB_DOMAIN + ' tab.');
     } else if (fromTabFlag) {
       console.error('No logged-in ' + KLICKHAUS_WEB_DOMAIN + ' tab found.');
       console.error('Open the klickhaus dashboard in the browser and log in, then retry — or pass --user/--password.');
       process.exit(1);
     }
+  }
+
+  if ((user && !password) || (!user && password)) {
+    console.error('Partial credential given: both --user and --password are required.');
+    console.error('Pass both, or use --from-tab to reuse a logged-in ' + KLICKHAUS_WEB_DOMAIN + ' tab.');
+    process.exit(1);
   }
 
   if (!user || !password) {
@@ -235,7 +246,7 @@ async function cmdLogin(args) {
     process.exit(1);
   }
 
-  await saveConfig({ user, password, logged_in_at: new Date().toISOString() });
+  await saveConfig({ user, password, logged_in_at: new Date().toISOString(), source });
   console.log('Login successful. Credentials saved to the klickhaus skill config (gitignored).');
   console.log('');
   console.log('Try:');


### PR DESCRIPTION
## What

Teach the `klickhaus` skill to reuse credentials from a logged-in klickhaus dashboard tab, so on-call engineers don't have to hunt for ClickHouse credentials mid-incident.

The klickhaus web dashboard (`klickhaus.aemstatus.net`) already stores the ClickHouse basic-auth credentials in `localStorage` under `clickhouse_credentials` (`{"user":"…","password":"…"}`). If that tab is open and logged in, the CLI can now pick them up automatically.

## Changes

`scripts/klickhaus.jsh`:
- New `credsFromTab()` helper — reads `localStorage.clickhouse_credentials` from an open, logged-in `klickhaus.aemstatus.net` tab via the `sliccy:browser` bridge. Fully guarded: no browser bridge / no tab / no stored creds all resolve to `null` (no throw), so nothing breaks in headless/CI contexts.
- `klickhaus login --from-tab` (and `--tab`) — explicitly reuse an open dashboard tab; falls back to it automatically when `--user`/`--password` are omitted.
- `ensureAuth()` now auto-detects from a logged-in tab when the skill config is empty, logs in transparently (persisting to the gitignored per-skill `.config`), and prints a one-line notice to **stderr** — so `status`/`errors`/`investigate` "just work" when the dashboard is open, with stdout still clean JSON.

`SKILL.md`:
- Documents `--from-tab` and the auto-detection behaviour (Quick start + command table).
- Corrects a stale Auth note: credentials are stored via the per-skill config bridge (gitignored `.config`), not `$HOME/.config/klickhaus/config.json`.

## Testing

Verified live during an on-call investigation (OCINC2488332):
- `klickhaus login --from-tab` → logged in from the open dashboard tab.
- Cleared the skill config, ran `klickhaus status` → auto-detected creds from the tab, saved them (`"source":"tab"`), returned normal results; notice went to stderr, JSON to stdout.

No credentials are committed — they live only in the gitignored `.config`.
