### PR TITLE
adobe-oncall: fix state values & shifts; add watch (auto-investigate new incidents)

### DIFF
--- a/skills/adobe-oncall/.gitignore
+++ b/skills/adobe-oncall/.gitignore
@@ -1,0 +1,3 @@
+# Runtime watch state (not source)
+.watch.json
+.watch-seen.json

--- a/skills/adobe-oncall/.gitignore
+++ b/skills/adobe-oncall/.gitignore
@@ -1,3 +1,0 @@
-# Runtime watch state (not source)
-.watch.json
-.watch-seen.json

--- a/skills/adobe-oncall/SKILL.md
+++ b/skills/adobe-oncall/SKILL.md
@@ -37,8 +37,8 @@ oncall who
 # View your upcoming shifts (next 14 days by default)
 oncall shifts
 
-# Auto-investigate new incidents via a scoop (legwork done before you ack)
-oncall watch --scoop oncall-investigator --interval 2
+# Auto-investigate new incidents via a scoop (event-driven off Slack escalations)
+oncall watch --scoop oncall-investigator --channel C01UB5Y1YQ7
 oncall unwatch
 
 # Monday protocol output
@@ -90,27 +90,42 @@ Show your upcoming on-call shifts (default 14-day window). Reports whether you'r
 on call now, when the current shift ends, and future shifts. Built on the calendar
 spans databroker (the old summary-card pipeline returned no data).
 
-### oncall watch --scoop <name> [--interval <min>] [--force]
+### oncall watch --scoop <name> [--channel <id>] [--workspace <id>] [--filter <js>] [--force]
 
-Auto-investigate new incidents. Registers a cron task (default every 2 minutes)
-routed to `<name>`; on each tick the scoop runs `oncall watch-poll` and, for any
-**new** incident, kicks off a klickhaus investigation per the RCA playbook and posts
-a findings work note — so by the time you manually ack, the legwork is underway. It
-does **not** change incident state (that stays a human decision). On start, the
-currently-active incidents are seeded as already-seen so only genuinely new ones
-fire. `oncall watch` with no args shows the current watch; `--force` replaces it.
+Auto-investigate new incidents — **event-driven, not polled**. Watches the Slack
+channel that receives ServiceNow escalation messages (default helix-ops
+`C01UB5Y1YQ7`; override with `--channel`) and wakes `<name>` **only** when a
+new-incident escalation arrives. On wake the scoop runs `oncall watch-poll` and,
+for any new incident, does a klickhaus RCA and posts a findings work note — so by
+the time you manually ack, the legwork is underway. It does **not** change
+incident state.
 
-The investigator scoop needs the browser tabs the skills use (a logged-in
-ServiceNow tab, and the klickhaus dashboard tab so klickhaus can auto-detect creds).
+Why event-driven: the "is there a new incident?" check needs an authenticated,
+async ServiceNow call, which a `crontask`/`webhook` filter (synchronous,
+session-less) can't do — so a cron poll would have to wake the LLM scoop on
+*every* tick, steadily filling its context with no-op polls. Triggering off the
+escalation message that ServiceNow already posts to Slack wakes the scoop only on
+real incidents.
+
+- `--channel <id>` — Slack channel that carries escalations (default helix-ops).
+- `--workspace <id>` — Slack workspace/enterprise id, if the channel isn't in the active tab's workspace.
+- `--filter <js>` — override the webhook filter (default keeps messages matching `/was escalated/`).
+- `oncall watch` (no args) shows the current watch; `--force` replaces it.
+
+Requires the `slack` skill (installed + logged in) — the Slack channel observation
+is delegated to `slack watch` with an escalation-only webhook filter. The
+investigator scoop needs the browser tabs the skills use (a logged-in ServiceNow
+tab; the klickhaus dashboard tab so klickhaus can auto-detect creds).
 
 ### oncall watch-poll [--json]
 
-List on-call incidents not yet surfaced (dedup via a local seen-set); idempotent,
-safe to run every tick. This is the detection engine the watcher scoop calls.
+List on-call incidents not yet surfaced (dedup via a local seen-set in `/shared/`);
+idempotent, safe to run on every wake. This is the detection engine the watcher
+scoop calls once woken by an escalation.
 
 ### oncall unwatch
 
-Stop watching: deletes the cron task and clears watch state.
+Stop watching: removes the Slack channel watch and clears watch state.
 
 ### oncall monday [--limit N] [--date Nd]
 
@@ -127,9 +142,11 @@ Output active incidents in monday aggregator protocol format.
 - **EMEA roster:** `a99c33f58360c7d00479abe0deaad33d` (03:00–15:00 UTC)
 - **NA roster:** `6f4df71c47f11610c49b3d54116d4335` (15:00–03:00 UTC)
 - **Access method:** XHR from ServiceNow workspace page context with `X-UserToken` header
-- **Watch:** cron task (`crontask`) routed to a scoop; detection/dedup in `watch-poll`.
-  Runtime state lives in `/shared/` (`/shared/.oncall-watch.json`, `/shared/.oncall-watch-seen.json`)
-  so the watcher scoop can write it too (`/workspace/skills` is read-only to scoops).
+- **Watch:** event-driven — delegates Slack channel observation to `slack watch`
+  with an escalation-only webhook filter; the woken scoop uses `watch-poll` for
+  detection/dedup. Runtime state in `/shared/` (`.oncall-watch.json`,
+  `.oncall-watch-seen.json`) so the scoop can write it (`/workspace/skills` is
+  read-only to scoops).
 - **On-Call app path:** `/x/adosy/on-call/home`
 
 ## Incident states

--- a/skills/adobe-oncall/SKILL.md
+++ b/skills/adobe-oncall/SKILL.md
@@ -128,7 +128,8 @@ Output active incidents in monday aggregator protocol format.
 - **NA roster:** `6f4df71c47f11610c49b3d54116d4335` (15:00–03:00 UTC)
 - **Access method:** XHR from ServiceNow workspace page context with `X-UserToken` header
 - **Watch:** cron task (`crontask`) routed to a scoop; detection/dedup in `watch-poll`.
-  Runtime state (gitignored): `.watch.json`, `.watch-seen.json`.
+  Runtime state lives in `/shared/` (`/shared/.oncall-watch.json`, `/shared/.oncall-watch-seen.json`)
+  so the watcher scoop can write it too (`/workspace/skills` is read-only to scoops).
 - **On-Call app path:** `/x/adosy/on-call/home`
 
 ## Incident states

--- a/skills/adobe-oncall/SKILL.md
+++ b/skills/adobe-oncall/SKILL.md
@@ -5,7 +5,8 @@ description: >-
   active on-call incidents, acknowledge, check who is on-call, view your
   upcoming shifts, and manage incident state. Use when the user mentions
   on-call, pagerduty, OCINC, incidents, shift schedule, acknowledge incident,
-  escalation, or wants to check on-call status.
+  escalation, or wants to check on-call status. Can also watch for new incidents
+  and auto-launch an investigation scoop so the legwork is done before you ack.
 allowed-tools: bash
 ---
 
@@ -33,8 +34,12 @@ oncall ack OCINC2145403
 # Check who is currently on-call
 oncall who
 
-# View your upcoming shifts
+# View your upcoming shifts (next 14 days by default)
 oncall shifts
+
+# Auto-investigate new incidents via a scoop (legwork done before you ack)
+oncall watch --scoop oncall-investigator --interval 2
+oncall unwatch
 
 # Monday protocol output
 oncall monday --limit 20 --date 7d
@@ -55,7 +60,7 @@ If the session has expired: "Session expired — open adobe.service-now.com/x/ad
 
 List active on-call incidents assigned to your groups.
 
-States: `open` (1), `wip` (2), `re-open` (60), `resolved` (3), `closed` (4), `all`
+States: `open` (1), `pending` (-5), `wip` (2), `resolved` (6), `cancelled` (8), `re-open` (60), `all`
 Default: open + wip + re-open
 
 ### oncall get <OCINC_NUMBER|sys_id>
@@ -69,7 +74,9 @@ Acknowledge an incident (sets acknowledged flag and assigns to you).
 
 ### oncall update <OCINC_NUMBER|sys_id> --state=STATE [--comment=TEXT]
 
-Update incident state. Optionally add a work note.
+Update incident state. Optionally add a work note. State names: `open`, `pending`,
+`wip`, `resolved`, `cancelled`, `re-open` (or pass a raw numeric value). To just add a
+work note without changing state, pass only `--comment`.
 
 ### oncall who [--group=GROUP]
 
@@ -77,9 +84,33 @@ Show who is currently on-call across **both EMEA and NA rosters**.
 Returns coverage (primary pager carrier) and shift (rotation slot) info.
 Uses the calendar spans databroker to get real-time schedule data.
 
-### oncall shifts
+### oncall shifts [--days=N]
 
-Show your upcoming on-call shifts.
+Show your upcoming on-call shifts (default 14-day window). Reports whether you're
+on call now, when the current shift ends, and future shifts. Built on the calendar
+spans databroker (the old summary-card pipeline returned no data).
+
+### oncall watch --scoop <name> [--interval <min>] [--force]
+
+Auto-investigate new incidents. Registers a cron task (default every 2 minutes)
+routed to `<name>`; on each tick the scoop runs `oncall watch-poll` and, for any
+**new** incident, kicks off a klickhaus investigation per the RCA playbook and posts
+a findings work note — so by the time you manually ack, the legwork is underway. It
+does **not** change incident state (that stays a human decision). On start, the
+currently-active incidents are seeded as already-seen so only genuinely new ones
+fire. `oncall watch` with no args shows the current watch; `--force` replaces it.
+
+The investigator scoop needs the browser tabs the skills use (a logged-in
+ServiceNow tab, and the klickhaus dashboard tab so klickhaus can auto-detect creds).
+
+### oncall watch-poll [--json]
+
+List on-call incidents not yet surfaced (dedup via a local seen-set); idempotent,
+safe to run every tick. This is the detection engine the watcher scoop calls.
+
+### oncall unwatch
+
+Stop watching: deletes the cron task and clears watch state.
 
 ### oncall monday [--limit N] [--date Nd]
 
@@ -89,21 +120,26 @@ Output active incidents in monday aggregator protocol format.
 
 - **Incident table:** `x_adosy_adb_on_ca_incident` (prefix: OCINC)
 - **Major incident table:** `x_adosy_mi_major_incident`
-- **Schedule API:** UX Framework Databroker pipeline `get_on_call_summary_info`
-  (definition: `1a7dd83d1b31b114fde1c8451a4bcba3`)
-- **Calendar API:** UX Framework Databroker pipeline `get_calendar_spans_1`
-  (definition: `b90d6f7a1be2fd10fde1c8451a4bcba6`) — returns both EMEA and NA rosters
+- **Schedule/shifts API:** UX Framework Databroker pipeline `get_calendar_spans_1`
+  (definition: `b90d6f7a1be2fd10fde1c8451a4bcba6`) — returns both EMEA and NA rosters;
+  used by both `who` and `shifts`. (The old `get_on_call_summary_info` pipeline
+  returned no data and is no longer used.)
 - **EMEA roster:** `a99c33f58360c7d00479abe0deaad33d` (03:00–15:00 UTC)
 - **NA roster:** `6f4df71c47f11610c49b3d54116d4335` (15:00–03:00 UTC)
 - **Access method:** XHR from ServiceNow workspace page context with `X-UserToken` header
+- **Watch:** cron task (`crontask`) routed to a scoop; detection/dedup in `watch-poll`.
+  Runtime state (gitignored): `.watch.json`, `.watch-seen.json`.
 - **On-Call app path:** `/x/adosy/on-call/home`
 
 ## Incident states
 
+Verified against the table's choice list / `g_form` (and a resolved record's `state.display_value`):
+
 | Value | Label |
 |-------|-------|
 | 1 | Open |
+| -5 | Pending |
 | 2 | Work in Progress |
-| 3 | Resolved |
-| 4 | Closed |
+| 6 | Resolved |
+| 8 | Cancelled |
 | 60 | Re-Open |

--- a/skills/adobe-oncall/scripts/oncall.jsh
+++ b/skills/adobe-oncall/scripts/oncall.jsh
@@ -24,6 +24,14 @@ const NA_ROSTER_ID = '6f4df71c47f11610c49b3d54116d4335';
 const WATCH_STATE = '/shared/.oncall-watch.json';
 const WATCH_SEEN = '/shared/.oncall-watch-seen.json';
 
+// Default Slack channel that receives ServiceNow escalation messages
+// (helix-ops). Override with `oncall watch --channel <id>`.
+const DEFAULT_WATCH_CHANNEL = 'C01UB5Y1YQ7';
+// Default webhook filter: forward only NEW-incident escalation messages to the
+// investigator scoop (drops resolutions/assignments/chatter before they wake
+// the agent). Override with `oncall watch --filter <js>`.
+const DEFAULT_ESCALATION_FILTER = "(e)=>{try{return /was escalated/i.test(JSON.stringify(e.body||e))}catch(_){return false}}";
+
 // Single-quote shell-escape for building `exec` command strings safely.
 function shq(s) { return "'" + String(s).replace(/'/g, "'\\''") + "'"; }
 
@@ -318,81 +326,76 @@ function readJsonFile(path, fallback) {
 
 // The standing instruction handed to the investigator scoop on each tick.
 // Must contain NO single quotes (it is embedded in a shell-escaped --filter).
-var WATCH_INSTRUCTION =
-  'Adobe on-call watch tick. Run this shell command: oncall watch-poll --json ' +
-  '-- it prints a JSON array of NEW (not-yet-investigated) on-call incidents (empty [] if none). ' +
-  'If it returns [], do nothing and stop. For each incident, start the investigation immediately so the ' +
-  'legwork is done before the human acks: follow the klickhaus RCA playbook (read /workspace/skills/klickhaus/SKILL.md) ' +
-  '-- klickhaus status; per-minute 5xx timeseries to find the burst; breakdown x_error to identify the subsystem; ' +
-  'localize by cdn.datacenter; scope by host (many tenants=infra, one=customer); confirm ongoing vs recovered. ' +
-  'Attribute the failure to the layer that emitted the error, and cross-tabulate to falsify. ' +
-  'Then post a concise findings work note to the incident with: oncall update <NUMBER> --comment=<your findings>. ' +
-  'Do NOT change incident state or resolve it -- leave that to the human.';
-
-// oncall watch --scoop <name> [--interval <min>] [--force]
-// Sets up a cron poller that wakes the given scoop; the scoop runs
-// `oncall watch-poll` and investigates any new incident. Also: `oncall watch`
-// (no args) shows status.
+// oncall watch --scoop <name> [--channel <id>] [--workspace <id>] [--filter <js>] [--force]
+// Event-driven: watches the Slack channel that receives ServiceNow escalation
+// messages (default helix-ops) and wakes the given scoop ONLY when a new-incident
+// escalation arrives — no polling, no empty wakes. The scoop then runs
+// `oncall watch-poll` and investigates. `oncall watch` (no args) shows status.
 async function cmdWatch(args) {
-  var scoop = null, interval = 2, force = false;
+  var scoop = null, channel = DEFAULT_WATCH_CHANNEL, workspace = null, filter = DEFAULT_ESCALATION_FILTER, force = false;
   for (var i = 0; i < (args || []).length; i++) {
-    if (args[i].startsWith('--scoop=')) scoop = args[i].split('=')[1];
-    else if (args[i] === '--scoop') scoop = args[i + 1];
-    else if (args[i].startsWith('--interval=')) interval = parseInt(args[i].split('=')[1], 10) || 2;
-    else if (args[i] === '--interval') interval = parseInt(args[i + 1], 10) || 2;
-    else if (args[i] === '--force') force = true;
+    var a = args[i];
+    if (a.startsWith('--scoop=')) scoop = a.split('=')[1];
+    else if (a === '--scoop') scoop = args[++i];
+    else if (a.startsWith('--channel=')) channel = a.split('=')[1];
+    else if (a === '--channel') channel = args[++i];
+    else if (a.startsWith('--workspace=')) workspace = a.split('=')[1];
+    else if (a === '--workspace') workspace = args[++i];
+    else if (a.startsWith('--filter=')) filter = a.split('=').slice(1).join('=');
+    else if (a === '--filter') filter = args[++i];
+    else if (a === '--force') force = true;
   }
 
   var existing = readJsonFile(WATCH_STATE, null);
 
   // No scoop → status view.
   if (!scoop) {
-    if (existing) {
-      console.log(JSON.stringify({ watching: true, scoop: existing.scoop, interval_min: existing.interval, cron_id: existing.cronId, since: existing.createdAt }, null, 2));
-    } else {
-      console.error('Not watching. Usage: oncall watch --scoop <name> [--interval <min>] [--force]');
-      process.exit(1);
-    }
+    if (existing) console.log(JSON.stringify({ watching: true, scoop: existing.scoop, channel: existing.channel, since: existing.createdAt }, null, 2));
+    else { console.error('Not watching. Usage: oncall watch --scoop <name> [--channel <id>] [--workspace <id>] [--filter <js>] [--force]'); process.exit(1); }
     return;
   }
 
   if (!/^[a-zA-Z0-9_-]+$/.test(scoop)) { console.error('Invalid --scoop "' + scoop + '". Alphanumeric, dash, underscore only.'); process.exit(1); }
-  if (!(interval >= 1 && interval <= 59)) { console.error('--interval must be 1-59 (minutes).'); process.exit(1); }
+  if (!/^[A-Za-z0-9]+$/.test(channel)) { console.error('Invalid --channel "' + channel + '".'); process.exit(1); }
+  if (workspace && !/^[A-Za-z0-9]+$/.test(workspace)) { console.error('Invalid --workspace "' + workspace + '".'); process.exit(1); }
 
-  if (existing && !force) {
-    console.error('Already watching (scoop: ' + existing.scoop + ', every ' + existing.interval + ' min). Use --force to replace.');
+  if (existing && !force) { console.error('Already watching (scoop: ' + existing.scoop + ', channel: ' + existing.channel + '). Use --force to replace.'); process.exit(1); }
+  if (existing) { await teardownWatch(existing).catch(function () {}); }
+
+  // Delegate the Slack channel observation to the slack skill: a filtered
+  // webhook (escalation-only) routed to the scoop. Requires the slack skill.
+  var wsArg = workspace ? (' --workspace ' + shq(workspace)) : '';
+  var forceArg = force ? ' --force' : '';
+  var watchCmd = 'slack watch ' + shq(channel) + ' --scoop ' + shq(scoop) + ' --filter ' + shq(filter) + wsArg + forceArg;
+  var res = await exec(watchCmd);
+  if (res.exitCode !== 0) {
+    console.error('Failed to start Slack channel watch:', (res.stderr || res.stdout || '').split('\n')[0]);
+    console.error('(The slack skill must be installed and logged in. Command: ' + watchCmd + ')');
     process.exit(1);
   }
-  if (existing && existing.cronId) {
-    await exec('crontask delete ' + shq(existing.cronId)).catch(function () {});
-  }
 
-  var cron = '*/' + interval + ' * * * *';
-  var filterJs = '() => ({ source: "oncall-watch", ts: Date.now(), instruction: "' + WATCH_INSTRUCTION + '" })';
-  var createCmd = 'crontask create --name ' + shq('oncall-watch') + ' --scoop ' + shq(scoop) + ' --cron ' + shq(cron) + ' --filter ' + shq(filterJs);
-  var res = await exec(createCmd);
-  if (res.exitCode !== 0) { console.error('Failed to create cron task:', res.stderr || res.stdout); process.exit(1); }
-  var idMatch = res.stdout.match(/^ID:\s*(\S+)/m);
-  if (!idMatch) { console.error('Could not parse cron task id from:', res.stdout.substring(0, 200)); process.exit(1); }
-  var cronId = idMatch[1];
-
-  // Seed the seen-set with CURRENTLY-active incidents so the watch only fires
-  // on genuinely new ones (existing open incidents are already known).
+  // Seed the seen-set with currently-active incidents so watch-poll only
+  // surfaces genuinely new ones.
   var nowIso = new Date().toISOString();
   var seen = {};
-  try {
-    var current = await fetchActiveIncidents();
-    for (var j = 0; j < current.length; j++) seen[current[j].sys_id] = nowIso;
-  } catch (e) { /* best effort */ }
+  try { var current = await fetchActiveIncidents(); for (var j = 0; j < current.length; j++) seen[current[j].sys_id] = nowIso; } catch (e) {}
   require('fs').writeFileSync(WATCH_SEEN, JSON.stringify({ updated: nowIso, seen: seen }, null, 2));
-  require('fs').writeFileSync(WATCH_STATE, JSON.stringify({ scoop: scoop, interval: interval, cronId: cronId, createdAt: nowIso }, null, 2));
+  require('fs').writeFileSync(WATCH_STATE, JSON.stringify({ scoop: scoop, channel: channel, workspace: workspace, filter: filter, mode: 'slack-escalation', createdAt: nowIso }, null, 2));
 
-  console.log('Watching on-call incidents -> scoop "' + scoop + '" (every ' + interval + ' min).');
-  console.log('  Cron task: ' + cronId);
+  console.log('Watching on-call escalations on Slack channel ' + channel + ' -> scoop "' + scoop + '".');
+  console.log('  Trigger: new-incident escalation message (event-driven; no polling).');
   console.log('  Seeded ' + Object.keys(seen).length + ' currently-active incident(s) as already-seen.');
-  console.log('  The scoop will run `oncall watch-poll` each tick and investigate new incidents.');
+  console.log('  The scoop runs `oncall watch-poll` on each escalation and investigates new incidents.');
   console.log('  Stop with: oncall unwatch');
 }
+
+// Tear down the underlying Slack channel watch for a given state object.
+async function teardownWatch(state) {
+  if (!state || !state.channel) return;
+  var wsArg = state.workspace ? (' --workspace ' + shq(state.workspace)) : '';
+  await exec('slack unwatch ' + shq(state.channel) + wsArg).catch(function () {});
+}
+
 
 // oncall watch-poll [--json]
 // Returns on-call incidents not yet surfaced (dedup via WATCH_SEEN). Idempotent;
@@ -434,10 +437,10 @@ async function cmdWatchPoll(args) {
 async function cmdUnwatch() {
   var existing = readJsonFile(WATCH_STATE, null);
   if (!existing) { console.log('Not watching.'); return; }
-  if (existing.cronId) await exec('crontask delete ' + shq(existing.cronId)).catch(function () {});
+  await teardownWatch(existing);
   try { require('fs').unlinkSync(WATCH_STATE); } catch (e) {}
   try { require('fs').unlinkSync(WATCH_SEEN); } catch (e) {}
-  console.log('Stopped watching (scoop: ' + existing.scoop + ', cron task ' + (existing.cronId || 'n/a') + ' deleted).');
+  console.log('Stopped watching (scoop: ' + existing.scoop + ', Slack channel ' + (existing.channel || 'n/a') + ' watch removed).');
 }
 
 // Fetch on-call calendar spans (events) for a UTC date window. Each event:
@@ -695,8 +698,9 @@ function showHelp() {
   console.log('                                Update incident state');
   console.log('  shifts [--days=N]             View your upcoming shifts (default 14 days)');
   console.log('  who [--group=ID]              Show who is on-call');
-  console.log('  watch --scoop <name> [--interval <min>] [--force]');
-  console.log('                                Auto-investigate new incidents via a scoop (default every 2 min)');
+  console.log('  watch --scoop <name> [--channel <id>] [--workspace <id>] [--filter <js>] [--force]');
+  console.log('                                Event-driven: wake a scoop to investigate on each new-incident');
+  console.log('                                escalation (Slack), so legwork is done before you ack');
   console.log('  watch-poll [--json]           List new (un-surfaced) incidents; used by the watcher scoop');
   console.log('  unwatch                       Stop watching');
   console.log('  history [--period=PERIOD]     Incidents for a time period');
@@ -710,7 +714,7 @@ function showHelp() {
   console.log('  oncall ack OCINC2145403');
   console.log('  oncall who');
   console.log('  oncall shifts');
-  console.log('  oncall watch --scoop oncall-investigator --interval 2');
+  console.log('  oncall watch --scoop oncall-investigator --channel C01UB5Y1YQ7');
 }
 
 // --- Main ---

--- a/skills/adobe-oncall/scripts/oncall.jsh
+++ b/skills/adobe-oncall/scripts/oncall.jsh
@@ -190,14 +190,14 @@ async function getCurrentUser() {
 
 // --- Commands ---
 
-var STATE_LABELS = { '1': 'Open', '2': 'Work in Progress', '3': 'Resolved', '4': 'Closed', '60': 'Re-Open' };
+var STATE_LABELS = { '1': 'Open', '-5': 'Pending', '2': 'Work in Progress', '6': 'Resolved', '8': 'Cancelled', '60': 'Re-Open' };
 
 async function cmdIncidents(args) {
   var stateFilter = '1,2,60';
   var groupId = null;
   for (var i = 0; i < args.length; i++) {
     if (args[i].startsWith('--state=')) {
-      var stateMap = { 'open': '1', 'wip': '2', 're-open': '60', 'resolved': '3', 'closed': '4', 'all': '1,2,3,4,60' };
+      var stateMap = { 'open': '1', 'pending': '-5', 'wip': '2', 'resolved': '6', 'cancelled': '8', 'canceled': '8', 're-open': '60', 'reopen': '60', 'all': '1,-5,2,6,8,60' };
       var val = args[i].split('=')[1];
       stateFilter = stateMap[val] || val;
     }
@@ -274,7 +274,11 @@ async function cmdUpdate(numberOrId, args) {
   var comment = '';
   for (var i = 0; i < args.length; i++) {
     if (args[i].startsWith('--state=')) {
-      var stateMap = { 'open': '1', 'wip': '2', 'resolved': '3', 'closed': '4', 're-open': '60' };
+      // On-Call Incident (x_adosy_adb_on_ca_incident) state values, verified live
+      // against the table's choice list / g_form: 1 Open, -5 Pending,
+      // 2 Work in Progress, 6 Resolved, 8 Cancelled, 60 Re-Open. Unknown names
+      // fall through as a raw value so a numeric state still works.
+      var stateMap = { 'open': '1', 'pending': '-5', 'wip': '2', 'resolved': '6', 'cancelled': '8', 'canceled': '8', 're-open': '60', 'reopen': '60' };
       var val = args[i].split('=')[1];
       body.state = stateMap[val] || val;
     }

--- a/skills/adobe-oncall/scripts/oncall.jsh
+++ b/skills/adobe-oncall/scripts/oncall.jsh
@@ -12,11 +12,18 @@ const DOMAIN = 'adobe.service-now.com';
 const ONCALL_PATH = '/x/adosy/on-call/home';
 const INCIDENT_TABLE = 'x_adosy_adb_on_ca_incident';
 const DATABROKER_ENDPOINT = '/api/now/uxf/databroker/exec';
-const SUMMARY_DEFINITION_ID = '1a7dd83d1b31b114fde1c8451a4bcba3';
 const CALENDAR_DEFINITION_ID = 'b90d6f7a1be2fd10fde1c8451a4bcba6';
 const DEFAULT_GROUP_ID = 'f3483b5047f11610c49b3d54116d4348'; // AEM - Helix v2
 const EMEA_ROSTER_ID = 'a99c33f58360c7d00479abe0deaad33d';
 const NA_ROSTER_ID = '6f4df71c47f11610c49b3d54116d4335';
+
+// Watch state (runtime artifacts, gitignored): the active watch config and the
+// set of incident sys_ids already surfaced (for dedup across polls).
+const WATCH_STATE = '/workspace/skills/adobe-oncall/.watch.json';
+const WATCH_SEEN = '/workspace/skills/adobe-oncall/.watch-seen.json';
+
+// Single-quote shell-escape for building `exec` command strings safely.
+function shq(s) { return "'" + String(s).replace(/'/g, "'\\''") + "'"; }
 
 let _tabId = null;
 
@@ -293,17 +300,223 @@ async function cmdUpdate(numberOrId, args) {
   console.log('Updated ' + numberOrId + '.');
 }
 
-async function cmdShifts() {
-  var payload = [{ type: 'GRAPHQL', definitionSysId: SUMMARY_DEFINITION_ID, inputValues: { groupSysId: { type: 'JSON_LITERAL', value: null }, userSysId: { type: 'JSON_LITERAL', value: null } }, pipelineId: 'get_on_call_summary_info' }];
+// Fetch active on-call incidents for the group (raw result rows).
+async function fetchActiveIncidents(stateFilter) {
+  var sf = stateFilter || '1,2,60';
+  var query = 'assignment_group=' + DEFAULT_GROUP_ID + '^active=true^stateIN' + sf + '^ORDERBYDESCopened_at';
+  var fields = 'number,short_description,state,priority,assigned_to,opened_at,sys_id';
+  var path = '/api/now/table/' + INCIDENT_TABLE + '?sysparm_query=' + encodeURIComponent(query) + '&sysparm_fields=' + fields + '&sysparm_limit=50&sysparm_display_value=true';
+  var data = await apiGet(path);
+  return (data && data.result) || [];
+}
+
+function readJsonFile(path, fallback) {
+  try { return JSON.parse(require('fs').readFileSync(path, 'utf8')); } catch (e) { return fallback; }
+}
+
+// The standing instruction handed to the investigator scoop on each tick.
+// Must contain NO single quotes (it is embedded in a shell-escaped --filter).
+var WATCH_INSTRUCTION =
+  'Adobe on-call watch tick. Run this shell command: oncall watch-poll --json ' +
+  '-- it prints a JSON array of NEW (not-yet-investigated) on-call incidents (empty [] if none). ' +
+  'If it returns [], do nothing and stop. For each incident, start the investigation immediately so the ' +
+  'legwork is done before the human acks: follow the klickhaus RCA playbook (read /workspace/skills/klickhaus/SKILL.md) ' +
+  '-- klickhaus status; per-minute 5xx timeseries to find the burst; breakdown x_error to identify the subsystem; ' +
+  'localize by cdn.datacenter; scope by host (many tenants=infra, one=customer); confirm ongoing vs recovered. ' +
+  'Attribute the failure to the layer that emitted the error, and cross-tabulate to falsify. ' +
+  'Then post a concise findings work note to the incident with: oncall update <NUMBER> --comment=<your findings>. ' +
+  'Do NOT change incident state or resolve it -- leave that to the human.';
+
+// oncall watch --scoop <name> [--interval <min>] [--force]
+// Sets up a cron poller that wakes the given scoop; the scoop runs
+// `oncall watch-poll` and investigates any new incident. Also: `oncall watch`
+// (no args) shows status.
+async function cmdWatch(args) {
+  var scoop = null, interval = 2, force = false;
+  for (var i = 0; i < (args || []).length; i++) {
+    if (args[i].startsWith('--scoop=')) scoop = args[i].split('=')[1];
+    else if (args[i] === '--scoop') scoop = args[i + 1];
+    else if (args[i].startsWith('--interval=')) interval = parseInt(args[i].split('=')[1], 10) || 2;
+    else if (args[i] === '--interval') interval = parseInt(args[i + 1], 10) || 2;
+    else if (args[i] === '--force') force = true;
+  }
+
+  var existing = readJsonFile(WATCH_STATE, null);
+
+  // No scoop → status view.
+  if (!scoop) {
+    if (existing) {
+      console.log(JSON.stringify({ watching: true, scoop: existing.scoop, interval_min: existing.interval, cron_id: existing.cronId, since: existing.createdAt }, null, 2));
+    } else {
+      console.error('Not watching. Usage: oncall watch --scoop <name> [--interval <min>] [--force]');
+      process.exit(1);
+    }
+    return;
+  }
+
+  if (!/^[a-zA-Z0-9_-]+$/.test(scoop)) { console.error('Invalid --scoop "' + scoop + '". Alphanumeric, dash, underscore only.'); process.exit(1); }
+  if (!(interval >= 1 && interval <= 59)) { console.error('--interval must be 1-59 (minutes).'); process.exit(1); }
+
+  if (existing && !force) {
+    console.error('Already watching (scoop: ' + existing.scoop + ', every ' + existing.interval + ' min). Use --force to replace.');
+    process.exit(1);
+  }
+  if (existing && existing.cronId) {
+    await exec('crontask delete ' + shq(existing.cronId)).catch(function () {});
+  }
+
+  var cron = '*/' + interval + ' * * * *';
+  var filterJs = '() => ({ source: "oncall-watch", ts: Date.now(), instruction: "' + WATCH_INSTRUCTION + '" })';
+  var createCmd = 'crontask create --name ' + shq('oncall-watch') + ' --scoop ' + shq(scoop) + ' --cron ' + shq(cron) + ' --filter ' + shq(filterJs);
+  var res = await exec(createCmd);
+  if (res.exitCode !== 0) { console.error('Failed to create cron task:', res.stderr || res.stdout); process.exit(1); }
+  var idMatch = res.stdout.match(/^ID:\s*(\S+)/m);
+  if (!idMatch) { console.error('Could not parse cron task id from:', res.stdout.substring(0, 200)); process.exit(1); }
+  var cronId = idMatch[1];
+
+  // Seed the seen-set with CURRENTLY-active incidents so the watch only fires
+  // on genuinely new ones (existing open incidents are already known).
+  var nowIso = new Date().toISOString();
+  var seen = {};
+  try {
+    var current = await fetchActiveIncidents();
+    for (var j = 0; j < current.length; j++) seen[current[j].sys_id] = nowIso;
+  } catch (e) { /* best effort */ }
+  require('fs').writeFileSync(WATCH_SEEN, JSON.stringify({ updated: nowIso, seen: seen }, null, 2));
+  require('fs').writeFileSync(WATCH_STATE, JSON.stringify({ scoop: scoop, interval: interval, cronId: cronId, createdAt: nowIso }, null, 2));
+
+  console.log('Watching on-call incidents -> scoop "' + scoop + '" (every ' + interval + ' min).');
+  console.log('  Cron task: ' + cronId);
+  console.log('  Seeded ' + Object.keys(seen).length + ' currently-active incident(s) as already-seen.');
+  console.log('  The scoop will run `oncall watch-poll` each tick and investigate new incidents.');
+  console.log('  Stop with: oncall unwatch');
+}
+
+// oncall watch-poll [--json]
+// Returns on-call incidents not yet surfaced (dedup via WATCH_SEEN). Idempotent;
+// safe to run every tick. This is the detection engine the watcher scoop calls.
+async function cmdWatchPoll(args) {
+  var asJson = (args || []).indexOf('--json') !== -1;
+  var store = readJsonFile(WATCH_SEEN, { seen: {} });
+  var seen = store.seen || {};
+  var incidents = await fetchActiveIncidents();
+
+  var nowMs = Date.now();
+  var nowIso = new Date().toISOString();
+  var fresh = [];
+  for (var i = 0; i < incidents.length; i++) {
+    var r = incidents[i];
+    if (!seen[r.sys_id]) {
+      fresh.push({
+        number: r.number,
+        short_description: (r.short_description || '').trim(),
+        priority: typeof r.priority === 'object' ? r.priority.display_value : r.priority,
+        state: typeof r.state === 'object' ? r.state.display_value : r.state,
+        opened: typeof r.opened_at === 'object' ? r.opened_at.display_value : r.opened_at,
+        sys_id: r.sys_id
+      });
+    }
+    seen[r.sys_id] = seen[r.sys_id] || nowIso;
+  }
+  // Prune seen entries older than 7 days to bound the file.
+  for (var k in seen) { if (nowMs - new Date(seen[k]).getTime() > 7 * 86400000) delete seen[k]; }
+  require('fs').writeFileSync(WATCH_SEEN, JSON.stringify({ updated: nowIso, seen: seen }, null, 2));
+
+  if (asJson) { console.log(JSON.stringify(fresh)); return; }
+  if (fresh.length === 0) { console.log('No new incidents.'); return; }
+  console.log(fresh.length + ' new incident(s):');
+  for (var m = 0; m < fresh.length; m++) console.log('  ' + fresh[m].number + '  [' + fresh[m].priority + ']  ' + fresh[m].short_description);
+}
+
+// oncall unwatch — tear down the active watch.
+async function cmdUnwatch() {
+  var existing = readJsonFile(WATCH_STATE, null);
+  if (!existing) { console.log('Not watching.'); return; }
+  if (existing.cronId) await exec('crontask delete ' + shq(existing.cronId)).catch(function () {});
+  try { require('fs').unlinkSync(WATCH_STATE); } catch (e) {}
+  try { require('fs').unlinkSync(WATCH_SEEN); } catch (e) {}
+  console.log('Stopped watching (scoop: ' + existing.scoop + ', cron task ' + (existing.cronId || 'n/a') + ' deleted).');
+}
+
+// Fetch on-call calendar spans (events) for a UTC date window. Each event:
+// { id, title:"Name (ROSTER)", start, end (ms-epoch strings), roster, group }.
+// Returns the events array or null. Shared by `shifts` (and mirrors the query
+// `who` uses).
+async function getCalendarSpans(startDate, endDate, groupSysId) {
+  var payload = [{
+    type: 'GRAPHQL',
+    definitionSysId: CALENDAR_DEFINITION_ID,
+    inputValues: { input: { type: 'JSON_LITERAL', value: { startDate: startDate, endDate: endDate, groupIds: groupSysId, userIds: null } } },
+    pipelineId: 'get_calendar_spans_1'
+  }];
   var data = await databrokerExec(payload);
-  var info = data.result && data.result[0] && data.result[0].executionResult && data.result[0].executionResult.output && data.result[0].executionResult.output.data && data.result[0].executionResult.output.data.xAdosyAdbOnCa && data.result[0].executionResult.output.data.xAdosyAdbOnCa.adbOnCall && data.result[0].executionResult.output.data.xAdosyAdbOnCa.adbOnCall.getSummaryCardInfo;
-  if (!info) { console.error('Could not retrieve schedule info.'); process.exit(1); }
+  return (data.result && data.result[0] && data.result[0].executionResult &&
+    data.result[0].executionResult.output && data.result[0].executionResult.output.data &&
+    data.result[0].executionResult.output.data.xAdosyAdbOnCa &&
+    data.result[0].executionResult.output.data.xAdosyAdbOnCa.adbOnCall &&
+    data.result[0].executionResult.output.data.xAdosyAdbOnCa.adbOnCall.getCalendarSpans &&
+    data.result[0].executionResult.output.data.xAdosyAdbOnCa.adbOnCall.getCalendarSpans.events) || null;
+}
+
+// Resolve the signed-in user's display name. window.NOW.user carries only a
+// sys_id in this instance, so fall back to a sys_user lookup.
+async function resolveUserName() {
+  var u = await getCurrentUser();
+  if (u && u.name) return u.name;
+  if (u && u.sys_id) {
+    var data = await apiGet('/api/now/table/sys_user/' + u.sys_id + '?sysparm_fields=name');
+    if (data && data.result && data.result.name) return data.result.name;
+  }
+  return null;
+}
+
+// Your upcoming on-call shifts. Rebuilt on the calendar-spans query (the old
+// summary-card GraphQL returned no data). `--days=N` sets the window (default 14).
+async function cmdShifts(args) {
+  var days = 14;
+  for (var i = 0; i < (args || []).length; i++) {
+    if (args[i].startsWith('--days=')) days = parseInt(args[i].split('=')[1], 10) || 14;
+  }
+
+  var name = await resolveUserName();
+  if (!name) { console.error('Could not determine the signed-in user.'); process.exit(1); }
+
+  var now = new Date();
+  var pad = function(n) { return n < 10 ? '0' + n : '' + n; };
+  var d0 = now.getUTCFullYear() + '-' + pad(now.getUTCMonth() + 1) + '-' + pad(now.getUTCDate());
+  var t2 = new Date(now.getTime() + days * 86400000);
+  var d1 = t2.getUTCFullYear() + '-' + pad(t2.getUTCMonth() + 1) + '-' + pad(t2.getUTCDate());
+
+  var events = await getCalendarSpans(d0, d1, DEFAULT_GROUP_ID);
+  if (!events) { console.error('Could not retrieve on-call calendar.'); process.exit(1); }
+
+  var nowMs = now.getTime();
+  var mine = [];
+  for (var j = 0; j < events.length; j++) {
+    var ev = events[j];
+    if (!ev.title || ev.title.indexOf('Shift:') === 0 || ev.title.indexOf('Roster:') === 0) continue;
+    if (ev.title.indexOf(name) === -1) continue; // titles are "Name (ROSTER)"
+    var startMs = parseInt(ev.start, 10), endMs = parseInt(ev.end, 10);
+    var rosterLabel = ev.roster === EMEA_ROSTER_ID ? 'EMEA' : (ev.roster === NA_ROSTER_ID ? 'NA' : ev.roster);
+    mine.push({ roster: rosterLabel, type: ev.title.indexOf('Coverage') !== -1 ? 'coverage' : 'shift', start: new Date(startMs).toISOString(), end: new Date(endMs).toISOString(), _s: startMs, _e: endMs });
+  }
+  mine.sort(function(a, b) { return a._s - b._s; });
+
+  var current = null, upcoming = [];
+  for (var k = 0; k < mine.length; k++) {
+    var m = mine[k];
+    if (nowMs >= m._s && nowMs < m._e) current = m;
+    else if (m._s > nowMs) upcoming.push(m);
+    delete m._s; delete m._e;
+  }
+
   var result = {
-    currently_oncall: info.userIsOnCall,
-    current_shifts: info.usersCurrentShifts || [],
-    upcoming_shifts: (info.usersFutureShifts || []).map(function(s) {
-      return { start: s.startDate, end: s.endDate, roster: s.roster, group: s.groupName };
-    })
+    user: name,
+    now: now.toISOString(),
+    on_call_now: !!current,
+    current_shift: current,
+    current_shift_ends: current ? current.end : null,
+    upcoming_shifts: upcoming
   };
   console.log(JSON.stringify(result, null, 2));
 }
@@ -478,8 +691,12 @@ function showHelp() {
   console.log('  ack <NUMBER>                  Acknowledge an incident');
   console.log('  update <NUMBER> --state=STATE [--comment=TEXT]');
   console.log('                                Update incident state');
-  console.log('  shifts                        View your upcoming shifts');
+  console.log('  shifts [--days=N]             View your upcoming shifts (default 14 days)');
   console.log('  who [--group=ID]              Show who is on-call');
+  console.log('  watch --scoop <name> [--interval <min>] [--force]');
+  console.log('                                Auto-investigate new incidents via a scoop (default every 2 min)');
+  console.log('  watch-poll [--json]           List new (un-surfaced) incidents; used by the watcher scoop');
+  console.log('  unwatch                       Stop watching');
   console.log('  history [--period=PERIOD]     Incidents for a time period');
   console.log('  monday [--limit N] [--date Nd]  Monday protocol output\n');
   console.log('Periods: today, yesterday, this_week, last_week (default), this_month, last_month');
@@ -491,6 +708,7 @@ function showHelp() {
   console.log('  oncall ack OCINC2145403');
   console.log('  oncall who');
   console.log('  oncall shifts');
+  console.log('  oncall watch --scoop oncall-investigator --interval 2');
 }
 
 // --- Main ---
@@ -508,7 +726,10 @@ switch (cmd) {
   case 'get': await cmdGet(args[0]); break;
   case 'ack': await cmdAck(args[0]); break;
   case 'update': await cmdUpdate(args[0], args.slice(1)); break;
-  case 'shifts': await cmdShifts(); break;
+  case 'shifts': await cmdShifts(args); break;
+  case 'watch': await cmdWatch(args); break;
+  case 'watch-poll': await cmdWatchPoll(args); break;
+  case 'unwatch': await cmdUnwatch(); break;
   case 'who': await cmdWhoIsOnCall(args); break;
   case 'whoisoncall': await cmdWhoIsOnCall(args); break;
   case 'history': await cmdHistory(args); break;

--- a/skills/adobe-oncall/scripts/oncall.jsh
+++ b/skills/adobe-oncall/scripts/oncall.jsh
@@ -17,10 +17,12 @@ const DEFAULT_GROUP_ID = 'f3483b5047f11610c49b3d54116d4348'; // AEM - Helix v2
 const EMEA_ROSTER_ID = 'a99c33f58360c7d00479abe0deaad33d';
 const NA_ROSTER_ID = '6f4df71c47f11610c49b3d54116d4335';
 
-// Watch state (runtime artifacts, gitignored): the active watch config and the
-// set of incident sys_ids already surfaced (for dedup across polls).
-const WATCH_STATE = '/workspace/skills/adobe-oncall/.watch.json';
-const WATCH_SEEN = '/workspace/skills/adobe-oncall/.watch-seen.json';
+// Watch state (runtime artifacts): the active watch config and the set of
+// incident sys_ids already surfaced (for dedup across polls). Kept in /shared/
+// so the watcher SCOOP can write them too (/workspace/skills is read-only to
+// scoops).
+const WATCH_STATE = '/shared/.oncall-watch.json';
+const WATCH_SEEN = '/shared/.oncall-watch-seen.json';
 
 // Single-quote shell-escape for building `exec` command strings safely.
 function shq(s) { return "'" + String(s).replace(/'/g, "'\\''") + "'"; }

--- a/skills/adobe-oncall/scripts/oncall.jsh
+++ b/skills/adobe-oncall/scripts/oncall.jsh
@@ -28,9 +28,11 @@ const WATCH_SEEN = '/shared/.oncall-watch-seen.json';
 // (helix-ops). Override with `oncall watch --channel <id>`.
 const DEFAULT_WATCH_CHANNEL = 'C01UB5Y1YQ7';
 // Default webhook filter: forward only NEW-incident escalation messages to the
-// investigator scoop (drops resolutions/assignments/chatter before they wake
-// the agent). Override with `oncall watch --filter <js>`.
-const DEFAULT_ESCALATION_FILTER = "(e)=>{try{return /was escalated/i.test(JSON.stringify(e.body||e))}catch(_){return false}}";
+// investigator scoop. Requires the "was escalated" text AND that the frame is a
+// genuine new root message — excludes thread replies / edits / broadcasts, whose
+// frames embed the parent's "was escalated" text and would otherwise re-trigger
+// on any reply in an escalation thread. Override with `oncall watch --filter <js>`.
+const DEFAULT_ESCALATION_FILTER = "(e)=>{try{var b=(e&&e.body)||{};if(b.subtype&&/replied|changed|deleted|broadcast/.test(b.subtype))return false;if(b.thread_ts&&b.thread_ts!==b.ts)return false;return /was escalated/i.test(JSON.stringify(b))}catch(_){return false}}";
 
 // Single-quote shell-escape for building `exec` command strings safely.
 function shq(s) { return "'" + String(s).replace(/'/g, "'\\''") + "'"; }


### PR DESCRIPTION
Three related `adobe-oncall` improvements from a live on-call session.

## 1. Correct incident **state values**

The skill used generic ITIL codes (`resolved:3`, `closed:4`); the `x_adosy_adb_on_ca_incident` table uses different values. Verified against the table's choice list / `g_form` and a resolved record's `state.display_value`:

| value | label | | value | label |
|--:|--|--|--:|--|
| `1` | Open | | `6` | Resolved |
| `-5` | Pending | | `8` | Cancelled |
| `2` | Work in Progress | | `60` | Re-Open |

Fixed in `STATE_LABELS`, both `--state` maps, and the SKILL.md states table. Unknown names still fall through as a raw value, so numeric `--state=<n>` keeps working.

## 2. Fix `oncall shifts`

The old summary-card GraphQL (`get_on_call_summary_info`) returned no data → "Could not retrieve schedule info". Rebuilt on the **calendar-spans** databroker (`get_calendar_spans_1`, the one `who` uses): resolves the signed-in user's name (via `sys_user`, since `window.NOW.user` only carries a sys_id), filters to that user over a window (`--days=N`, default 14), and reports whether you're on call now, when the current shift ends, and upcoming shifts. Removed the dead `SUMMARY_DEFINITION_ID`.

## 3. Add `oncall watch` — **event-driven** auto-investigation of new incidents

`oncall watch --scoop <name> [--channel <id>] [--workspace <id>] [--filter <js>] [--force]` wakes an investigator scoop the moment a new incident lands, so the RCA legwork is done before you manually ack. It does **not** change incident state.

**Why event-driven (not a cron poll):** the "is there a new incident?" check needs an authenticated, async ServiceNow call — which a `crontask`/`webhook` filter (synchronous, session-less) can't do. A cron poll would therefore have to wake the LLM scoop on *every* tick, steadily filling its context with no-op polls. Instead we trigger off the escalation message ServiceNow already posts to Slack, so the scoop wakes **only** on real incidents.

- Delegates Slack channel observation to `slack watch` with an **escalation-only** webhook filter (default keeps `/was escalated/`), routed to the scoop. Channel is configurable via `--channel` (default helix-ops `C01UB5Y1YQ7`); `--workspace` for Enterprise Grid; `--filter` to override.
- On wake the scoop runs **`oncall watch-poll`** (new; stateless dedup via a `/shared/` seen-set, idempotent) and investigates any new incident per the klickhaus RCA playbook, posting a preliminary work note.
- `oncall unwatch` removes the Slack channel watch and clears state. `oncall watch` (no args) shows status.
- Runtime state lives in `/shared/` (`.oncall-watch.json`, `.oncall-watch-seen.json`) so the scoop can write it (`/workspace/skills` is read-only to scoops).

Depends on the `slack` skill's `watch --filter` (ai-ecoverse/skills#276).

## Testing

- `oncall shifts` → correct current shift end + `--days`.
- States labeled correctly (used live to resolve OCINC2488647).
- `oncall watch` / `unwatch` verified live: creates the filtered Slack watch (webhook shows `[filtered]`) routed to the scoop, seeds already-seen incidents, and tears down cleanly; `watch-poll --json` dedups across runs. Ran a live event-driven watcher end-to-end during the shift.
